### PR TITLE
check status code for k8s cluster up curl check instead of output text

### DIFF
--- a/wkops.sh
+++ b/wkops.sh
@@ -110,10 +110,10 @@ create() {
   kops create secret --name ${K8S_CLUSTER_NAME} sshpublickey admin -i ~/.ssh/kops.pub
   kops update cluster ${K8S_CLUSTER_NAME} --yes
 
-  OUTPUT=''
-  while [ -z "$OUTPUT" ]; do
-    OUTPUT=`curl -s --insecure https://api.${K8S_CLUSTER_NAME}`
-    if [ "$OUTPUT" == "Unauthorized" ]
+  STATUS_CODE="000"
+  while [ "$STATUS_CODE" == "000" ]; do
+    STATUS_CODE=`curl -s -o /dev/null -w "%{http_code}" --insecure https://api.${K8S_CLUSTER_NAME}`
+    if [ "$STATUS_CODE" == "401" ]
     then
       installSecrets
       installIngresses
@@ -123,7 +123,7 @@ create() {
       buildDashboard
       helm init --kube-context $K8S_CLUSTER_NAME
     else
-      echo "Cluster is not ready yet" && sleep 45
+      echo "Cluster is not ready yet... ( https://api.${K8S_CLUSTER_NAME} curl status code: $STATUS_CODE ) " && sleep 45
     fi
   done
 }


### PR DESCRIPTION
k8s > 1.6.0

```
bash-4.3# curl -s --insecure https://api.${K8S_CLUSTER_NAME}
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {

  },
  "status": "Failure",
  "message": "Unauthorized",
  "reason": "Unauthorized",
  "code": 401
}bash-4.3# 
```

k8s <= 1.6.0

```
bash-4.3# curl -s --insecure https://api.${K8S_CLUSTER_NAME}
Unauthorized
bash-4.3#

```

Checking for status code is a bit more consistent across versions and also immune from any future changes

```
curl -s -o /dev/null -w "%{http_code}" --insecure https://api.${K8S_CLUSTER_NAME}
401
```
